### PR TITLE
Ensure mirror input field is correctly updated when the source input field is empty...

### DIFF
--- a/jquery.autosize.input.js
+++ b/jquery.autosize.input.js
@@ -48,7 +48,7 @@ var Plugins;
             if(value === this._mirror.text()) {
                 return;
             }
-            this._mirror.text(value);
+            this._mirror.text(value || "");
             var newWidth = this._mirror.width() + this._options.space;
             this._input.width(newWidth);
         };

--- a/jquery.autosize.input.ts
+++ b/jquery.autosize.input.ts
@@ -75,7 +75,7 @@ module Plugins
 			}
 
 			// Update mirror
-			this._mirror.text(value);
+			this._mirror.text(value || "");
 
 			// Update the width
 			var newWidth = this._mirror.width() + this._options.space;


### PR DESCRIPTION
Hello,

I am integrating this component into a component I wrote (https://github.com/jblashill/recipients.ui.js) and came across this issue. Luckily the fix was an easy one:

AutosizeInput.update() doesn't correctly update the mirror when the source input field is empty.

(Tested on Chrome 27)

Thanks,
James
