### PR TITLE
Fixed hoisting bug and TS compilation issue

### DIFF
--- a/jquery.autosize.input.js
+++ b/jquery.autosize.input.js
@@ -1,3 +1,4 @@
+
 var Plugins;
 (function (Plugins) {
     var AutosizeInput = (function () {
@@ -91,7 +92,7 @@ var Plugins;
 
                 if (!$this.data(Plugins.AutosizeInput.instanceKey)) {
                     if (options == undefined) {
-                        var options = $this.data(pluginDataAttributeName);
+                        options = $this.data(pluginDataAttributeName);
 
                         if (!(options && typeof options == 'object')) {
                             options = new AutosizeInputOptions();

--- a/jquery.autosize.input.ts
+++ b/jquery.autosize.input.ts
@@ -45,7 +45,7 @@ module Plugins
 			this._input.on("keydown keyup input propertychange change", (e) => { this.update(); });
 
 			// Update
-			() => { this.update(); } ();
+			(() => { this.update(); }) ();
 		}
 
 		public get options(): IAutosizeInputOptions
@@ -131,7 +131,7 @@ module Plugins
 					if (options == undefined)
 					{
 						// Try get options from attribute
-						var options = $this.data(pluginDataAttributeName);
+						options = $this.data(pluginDataAttributeName);
 
 						if (!(options && typeof options == 'object')) 
 						{


### PR DESCRIPTION
Option arguments to autosizeInput() were ignored due to a hoisting issue. This commit should fix issue #11.
