### PR TITLE
Set a correct behaviour using the placeholder

### DIFF
--- a/jquery.autosize.input.js
+++ b/jquery.autosize.input.js
@@ -44,7 +44,7 @@ var Plugins;
         };
 
         AutosizeInput.prototype.update = function () {
-            var value = this._input.val() || "";
+            var value = this._input.val() || this._input.attr('placeholder');
 
             if (value === this._mirror.text()) {
                 // Nothing have changed - skip


### PR DESCRIPTION
Sometimes we want to have a dynamic width even when the input is smaller than the placeholder.
To do that, we may drop the width css attribute.

Here is an example. Please input some text, then erase it.
http://jsfiddle.net/mJMpw/695/

The trick is to use the placeholder text as a default if there is no value in the input.
